### PR TITLE
Update logic to run when true

### DIFF
--- a/templates/divvy_volumes_without_recent_snapshot.json
+++ b/templates/divvy_volumes_without_recent_snapshot.json
@@ -2,19 +2,19 @@
     "uuid": "divvy.volumes_without_recent_snapshot",
     "name": "Volumes Without A Recent Snapshot",
     "category": "Best Practices",
-    "description": "Identify volumes without a snapshot in the past fourteen days",
+    "description": "Identify volumes without a snapshot in the past X days with 30 days as default",
     "instructions": {
         "actions": [
             {
                 "config": {},
                 "name": "divvy.action.mark_non_compliant",
-                "run_when_result_is": false
+                "run_when_result_is": true
             }
         ],
         "filters": [
             {
                 "config": {
-                    "days": 14
+                    "days": 30
                 },
                 "name": "divvy.filter.recent_volume_snapshots"
             }


### PR DESCRIPTION
1) Filters on volumes without recent snapshots, but marked non-matches non-compliant, so updated run_when_result_is from false 
2) Description and passed value = 14 days, but filter says default is 30 days, so updated description/passed value